### PR TITLE
[JSFIX] Major version upgrade of commander from version 8.1.0 to 9.4.0

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1827,11 +1827,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
-      "integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
       "engines": {
-        "node": ">= 12"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/common-path-prefix": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/types": "^7.1.1",
         "adm-zip": "^0.5.9",
-        "commander": "^8.1.0",
+        "commander": "^9.4.0",
         "console-log-level": "^1.4.1",
         "del": "^6.0.0",
         "fast-deep-equal": "^3.1.3",
@@ -1884,11 +1884,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
-      "integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
       "engines": {
-        "node": ">= 12"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/common-path-prefix": {
@@ -7390,9 +7390,9 @@
       }
     },
     "commander": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
-      "integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA=="
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
     },
     "common-path-prefix": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/types": "^7.1.1",
     "adm-zip": "^0.5.9",
-    "commander": "^8.1.0",
+    "commander": "^9.4.0",
     "console-log-level": "^1.4.1",
     "del": "^6.0.0",
     "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
This pull request was created by [barslev](https://github.com/barslev) using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It upgrades commander to version 9.4.0.

The JSFIX tool used advanced program analysis to determine how commander is used by codeql-action and how it is affected by breaking changes in commander version 9.4.0 (see details below). JSFIX checked for the 3 breaking changes affecting commander version 9.4.0 and found 2 occurrences in codeql-action. 1 of the occurrences must be manually audited. 1 of the occurrences are unlikely to affect your code, but we recommend manually reviewing them (see details below).

<strong>Install the [JSFIX GitHub app](https://github.com/apps/jsfix-updater) to receive other package upgrades from JSFIX.</strong>

***

<h3>Breaking change details</h3>

<details open><summary><strong> 🚧 - Not automatically fixed breaking changes (please check before merging)</strong></summary><blockquote class="pr-blockquote"><details open>
<summary>Affects all applications (not related to specific API usages in your code).</summary>

* Commander 9 requires Node.js v12.20.0 or higher
</details>

<details>
<summary>Unlikely breaking changes (Your code is probably not affected, but JSFIX is uncertain).</summary><blockquote class="pr-blockquote">



* removed internal fallback to require.main.filename when script not known from arguments passed to .parse()
  * Hint for the match below: Only relevant if you depend on commander auto-generating a specific name for your application, which is typically only the case if you use standalone executable subcommands. In that case, you can always set the name manually using the `.name` method or specify the location of the executable subcommand using the `.executableDir` method. For a detailed explanation of this problem see the PR: https://github.com/tj/commander.js/pull/1571
    * [src/runner.ts#L625-L625](https://github.com/barslev/codeql-action/blob/aaca8193b16d8aa07c108ae27096823139a1997a/src/runner.ts#L625-L625)
</blockquote></details>

</blockquote></details><details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* Changed/Fixed the behaviour of default values for non-boolean options so it now works as documented here https://github.com/tj/commander.js/tree/v8.0.0#default-option-value (like boolean options)
</details>



***

<strong>Visit [https://jsfix.live/about-jsfix](https://jsfix.live/about-jsfix) to learn more about how JSFIX works.</strong>


If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.